### PR TITLE
Allow selling items to an shop. Checked full inventories.

### DIFF
--- a/src/main/java/io/github/hsyyid/spongychest/SpongyChest.java
+++ b/src/main/java/io/github/hsyyid/spongychest/SpongyChest.java
@@ -37,6 +37,7 @@ import org.spongepowered.api.config.DefaultConfig;
 import org.spongepowered.api.data.DataQuery;
 import org.spongepowered.api.data.key.Key;
 import org.spongepowered.api.data.key.KeyFactory;
+import org.spongepowered.api.data.value.mutable.ListValue;
 import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.game.state.GameInitializationEvent;
@@ -61,10 +62,14 @@ public class SpongyChest
 	public static Set<ChestShopModifier> chestShopModifiers = Sets.newHashSet();
 
 	// Keys
+	public static int SELL_PRICE_INDEX = 0;
+	public static int BUY_PRICE_INDEX = 1;
 	public static final Key<Value<Boolean>> IS_SPONGY_CHEST = KeyFactory.makeSingleKey(Boolean.class, Value.class, DataQuery.of("IsSpongyChest"));
 	public static final Key<Value<UUID>> UUID_CHEST = KeyFactory.makeSingleKey(UUID.class, Value.class, DataQuery.of("UUIDChest"));
 	public static final Key<Value<ItemStackSnapshot>> ITEM_CHEST = KeyFactory.makeSingleKey(ItemStackSnapshot.class, Value.class, DataQuery.of("ItemChest"));
-	public static final Key<Value<Double>> PRICE_CHEST = KeyFactory.makeSingleKey(Double.class, Value.class, DataQuery.of("PriceChest"));
+	public static final Key<ListValue<Double>> PRICES_CHEST = KeyFactory.makeListKey(Double.class, DataQuery.of("PricesChest"));
+	public static final Key<Value<Double>> SELL_PRICE_CHEST = KeyFactory.makeSingleKey(Double.class, Value.class, DataQuery.of("SellPriceChest"));
+	public static final Key<Value<Double>> BUY_PRICE_CHEST = KeyFactory.makeSingleKey(Double.class, Value.class, DataQuery.of("SellPriceChest"));
 
 	@Inject
 	private Logger logger;
@@ -92,7 +97,22 @@ public class SpongyChest
 		subcommands.put(Arrays.asList("setshop"), CommandSpec.builder()
 			.description(Text.of("Creates SpongyChest shops"))
 			.permission("spongychest.setshop.command")
-			.arguments(GenericArguments.doubleNum(Text.of("price")))
+			.arguments(
+					GenericArguments.firstParsing(
+							GenericArguments.seq(
+									GenericArguments.doubleNum(Text.of("sell-price")),
+									GenericArguments.optional(
+											GenericArguments.doubleNum(Text.of("buy-price"))
+											)
+									),
+							GenericArguments.flags()
+							.valueFlag(GenericArguments.doubleNum(Text.of("sell-price")), "s")
+							.valueFlag(GenericArguments.doubleNum(Text.of("buy-price")), "b")
+							.flag("-sell-price")
+							.flag("-buy-price")
+							.buildWith(GenericArguments.none())
+							)
+					)
 			.executor(new SetShopExecutor())
 			.build());
 

--- a/src/main/java/io/github/hsyyid/spongychest/SpongyChest.java
+++ b/src/main/java/io/github/hsyyid/spongychest/SpongyChest.java
@@ -68,8 +68,8 @@ public class SpongyChest
 	public static final Key<Value<UUID>> UUID_CHEST = KeyFactory.makeSingleKey(UUID.class, Value.class, DataQuery.of("UUIDChest"));
 	public static final Key<Value<ItemStackSnapshot>> ITEM_CHEST = KeyFactory.makeSingleKey(ItemStackSnapshot.class, Value.class, DataQuery.of("ItemChest"));
 	public static final Key<ListValue<Double>> PRICES_CHEST = KeyFactory.makeListKey(Double.class, DataQuery.of("PricesChest"));
-	public static final Key<Value<Double>> SELL_PRICE_CHEST = KeyFactory.makeSingleKey(Double.class, Value.class, DataQuery.of("SellPriceChest"));
-	public static final Key<Value<Double>> BUY_PRICE_CHEST = KeyFactory.makeSingleKey(Double.class, Value.class, DataQuery.of("SellPriceChest"));
+	public static final Key<Value<Double>> SELL_PRICE_CHEST = KeyFactory.makeSingleKey(Double.class, Value.class, DataQuery.of("PriceChest"));
+	public static final Key<Value<Double>> BUY_PRICE_CHEST = KeyFactory.makeSingleKey(Double.class, Value.class, DataQuery.of("BuyPriceChest"));
 
 	@Inject
 	private Logger logger;

--- a/src/main/java/io/github/hsyyid/spongychest/SpongyChest.java
+++ b/src/main/java/io/github/hsyyid/spongychest/SpongyChest.java
@@ -26,6 +26,7 @@ import io.github.hsyyid.spongychest.data.uuidchest.UUIDChestData;
 import io.github.hsyyid.spongychest.data.uuidchest.UUIDChestDataBuilder;
 import io.github.hsyyid.spongychest.listeners.HitBlockListener;
 import io.github.hsyyid.spongychest.listeners.InteractBlockListener;
+import io.github.hsyyid.spongychest.listeners.ItemFrameListener;
 import io.github.hsyyid.spongychest.utils.ChestShopModifier;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
@@ -127,6 +128,7 @@ public class SpongyChest
 
 		Sponge.getEventManager().registerListeners(this, new InteractBlockListener());
 		Sponge.getEventManager().registerListeners(this, new HitBlockListener());
+		Sponge.getEventManager().registerListeners(this, new ItemFrameListener());
 
 		// Chest
 		Sponge.getDataManager().register(IsSpongyChestData.class, ImmutableIsSpongyChestData.class, new IsSpongyChestDataBuilder());

--- a/src/main/java/io/github/hsyyid/spongychest/commands/SetShopExecutor.java
+++ b/src/main/java/io/github/hsyyid/spongychest/commands/SetShopExecutor.java
@@ -19,7 +19,12 @@ public class SetShopExecutor implements CommandExecutor
 	@Override
 	public CommandResult execute(CommandSource src, CommandContext ctx) throws CommandException
 	{
-		BigDecimal price = new BigDecimal(ctx.<Double> getOne("price").get());
+		if (!ctx.hasAny("sell-price") && !ctx.hasAny("buy-price"))
+		{
+			CommandResult.empty();
+		}
+		BigDecimal sellPrice = new BigDecimal(ctx.<Double> getOne("sell-price").orElse(0D));
+		BigDecimal buyPrice = new BigDecimal(ctx.<Double> getOne("buy-price").orElse(0D));
 
 		if (src instanceof Player)
 		{
@@ -29,7 +34,7 @@ public class SetShopExecutor implements CommandExecutor
 			{
 				Optional<ChestShopModifier> modifier = SpongyChest.chestShopModifiers.stream().filter(m -> m.getUuid().equals(player.getUniqueId())).findAny();
 
-				ChestShopModifier chestShopModifier = new ChestShopModifier(player.getUniqueId(), player.getItemInHand().get().createSnapshot(), price);
+				ChestShopModifier chestShopModifier = new ChestShopModifier(player.getUniqueId(), player.getItemInHand().get().createSnapshot(), sellPrice, buyPrice);
 
 				if (modifier.isPresent())
 				{

--- a/src/main/java/io/github/hsyyid/spongychest/data/pricechest/ImmutablePriceChestData.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/pricechest/ImmutablePriceChestData.java
@@ -1,9 +1,12 @@
 package io.github.hsyyid.spongychest.data.pricechest;
 
-import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.manipulator.immutable.ImmutableListData;
+import org.spongepowered.api.data.value.immutable.ImmutableListValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 
-public interface ImmutablePriceChestData extends ImmutableDataManipulator<ImmutablePriceChestData, PriceChestData>
+public interface ImmutablePriceChestData extends ImmutableListData<Double, ImmutablePriceChestData, PriceChestData>
 {
-	ImmutableValue<Double> price();
+	ImmutableListValue<Double> prices();
+	ImmutableValue<Double> sellPrice();
+	ImmutableValue<Double> buyPrice();
 }

--- a/src/main/java/io/github/hsyyid/spongychest/data/pricechest/ImmutableSpongePriceChestData.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/pricechest/ImmutableSpongePriceChestData.java
@@ -1,33 +1,28 @@
 package io.github.hsyyid.spongychest.data.pricechest;
 
-import com.google.common.collect.ComparisonChain;
 import io.github.hsyyid.spongychest.SpongyChest;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.key.Key;
-import org.spongepowered.api.data.manipulator.immutable.common.AbstractImmutableSingleData;
+import org.spongepowered.api.data.manipulator.immutable.common.AbstractImmutableListData;
 import org.spongepowered.api.data.value.BaseValue;
+import org.spongepowered.api.data.value.immutable.ImmutableListValue;
 import org.spongepowered.api.data.value.immutable.ImmutableValue;
 
+import java.util.List;
 import java.util.Optional;
 
-public class ImmutableSpongePriceChestData extends AbstractImmutableSingleData<Double, ImmutablePriceChestData, PriceChestData> implements ImmutablePriceChestData
+public class ImmutableSpongePriceChestData extends AbstractImmutableListData<Double, ImmutablePriceChestData, PriceChestData> implements ImmutablePriceChestData
 {
-	public ImmutableSpongePriceChestData(Double value)
+	public ImmutableSpongePriceChestData(List<Double> value)
 	{
-		super(value, SpongyChest.PRICE_CHEST);
-	}
-
-	@Override
-	protected ImmutableValue<Double> getValueGetter()
-	{
-		return price();
+		super(value, SpongyChest.PRICES_CHEST);
 	}
 
 	@Override
 	public DataContainer toContainer()
 	{
-		return super.toContainer().set(SpongyChest.PRICE_CHEST.getQuery(), this.getValue());
+		return super.toContainer().set(SpongyChest.PRICES_CHEST.getQuery(), this.getValue());
 	}
 	
 	@Override
@@ -37,17 +32,9 @@ public class ImmutableSpongePriceChestData extends AbstractImmutableSingleData<D
 	}
 
 	@Override
-	public ImmutableValue<Double> price()
+	public ImmutableListValue<Double> prices()
 	{
-		return Sponge.getRegistry().getValueFactory().createValue(SpongyChest.PRICE_CHEST, this.getValue()).asImmutable();
-	}
-
-	@Override
-	public int compareTo(ImmutablePriceChestData o)
-	{
-		return ComparisonChain.start()
-			.compare(price().get(), o.price().get())
-			.result();
+		return Sponge.getRegistry().getValueFactory().createListValue(SpongyChest.PRICES_CHEST, this.getValue()).asImmutable();
 	}
 
 	@Override
@@ -67,5 +54,15 @@ public class ImmutableSpongePriceChestData extends AbstractImmutableSingleData<D
 	public int getContentVersion()
 	{
 		return 1;
+	}
+
+	@Override
+	public ImmutableValue<Double> sellPrice() {
+		return Sponge.getRegistry().getValueFactory().createValue(SpongyChest.SELL_PRICE_CHEST, this.getValue().get(SpongyChest.SELL_PRICE_INDEX)).asImmutable();
+	}
+
+	@Override
+	public ImmutableValue<Double> buyPrice() {
+		return Sponge.getRegistry().getValueFactory().createValue(SpongyChest.BUY_PRICE_CHEST, this.getValue().get(SpongyChest.BUY_PRICE_INDEX)).asImmutable();
 	}
 }

--- a/src/main/java/io/github/hsyyid/spongychest/data/pricechest/PriceChestData.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/pricechest/PriceChestData.java
@@ -1,9 +1,12 @@
 package io.github.hsyyid.spongychest.data.pricechest;
 
-import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.mutable.ListData;
+import org.spongepowered.api.data.value.mutable.ListValue;
 import org.spongepowered.api.data.value.mutable.Value;
 
-public interface PriceChestData extends DataManipulator<PriceChestData, ImmutablePriceChestData>
+public interface PriceChestData extends ListData<Double, PriceChestData, ImmutablePriceChestData>
 {
-	Value<Double> price();
+	ListValue<Double> prices();
+	Value<Double> sellPrice();
+	Value<Double> buyPrice();
 }

--- a/src/main/java/io/github/hsyyid/spongychest/data/pricechest/PriceChestDataBuilder.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/pricechest/PriceChestDataBuilder.java
@@ -5,6 +5,7 @@ import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataView;
 import org.spongepowered.api.data.manipulator.DataManipulatorBuilder;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,6 +28,16 @@ public class PriceChestDataBuilder implements DataManipulatorBuilder<PriceChestD
 	{
 		if (!container.contains(SpongyChest.PRICES_CHEST.getQuery()))
 		{
+			if (container.contains(SpongyChest.SELL_PRICE_CHEST.getQuery()))
+			{
+				List<Double> values = new ArrayList<>(2);
+				values.add(SpongyChest.SELL_PRICE_INDEX, (Double)container.get(SpongyChest.SELL_PRICE_CHEST.getQuery()).get());
+				values.add(SpongyChest.BUY_PRICE_INDEX, 0D);
+				PriceChestData data = new SpongePriceChestData(values);
+				container.remove(SpongyChest.SELL_PRICE_CHEST.getQuery());
+				container.set(SpongyChest.PRICES_CHEST.getQuery(), data);
+				return Optional.of(data);
+			}
 			return Optional.empty();
 		}
 

--- a/src/main/java/io/github/hsyyid/spongychest/data/pricechest/PriceChestDataBuilder.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/pricechest/PriceChestDataBuilder.java
@@ -5,6 +5,7 @@ import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataView;
 import org.spongepowered.api.data.manipulator.DataManipulatorBuilder;
 
+import java.util.List;
 import java.util.Optional;
 
 public class PriceChestDataBuilder implements DataManipulatorBuilder<PriceChestData, ImmutablePriceChestData>
@@ -24,12 +25,12 @@ public class PriceChestDataBuilder implements DataManipulatorBuilder<PriceChestD
 	@Override
 	public Optional<PriceChestData> build(DataView container)
 	{
-		if (!container.contains(SpongyChest.PRICE_CHEST.getQuery()))
+		if (!container.contains(SpongyChest.PRICES_CHEST.getQuery()))
 		{
 			return Optional.empty();
 		}
 
-		PriceChestData data = new SpongePriceChestData((Double) container.get(SpongyChest.PRICE_CHEST.getQuery()).get());
+		PriceChestData data = new SpongePriceChestData((List<Double>) container.get(SpongyChest.PRICES_CHEST.getQuery()).get());
 		return Optional.of(data);
 	}
 }

--- a/src/main/java/io/github/hsyyid/spongychest/data/pricechest/SpongePriceChestData.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/pricechest/SpongePriceChestData.java
@@ -1,47 +1,50 @@
 package io.github.hsyyid.spongychest.data.pricechest;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ComparisonChain;
 import io.github.hsyyid.spongychest.SpongyChest;
+
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataHolder;
 import org.spongepowered.api.data.DataQuery;
-import org.spongepowered.api.data.manipulator.mutable.common.AbstractSingleData;
+import org.spongepowered.api.data.manipulator.mutable.common.AbstractListData;
 import org.spongepowered.api.data.merge.MergeFunction;
+import org.spongepowered.api.data.value.mutable.ListValue;
 import org.spongepowered.api.data.value.mutable.Value;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
-public class SpongePriceChestData extends AbstractSingleData<Double, PriceChestData, ImmutablePriceChestData> implements PriceChestData
+public class SpongePriceChestData extends AbstractListData<Double, PriceChestData, ImmutablePriceChestData> implements PriceChestData
 {
 	public SpongePriceChestData()
 	{
-		this(0d);
+		this(new ArrayList<>(2));
 	}
 
-	public SpongePriceChestData(Double value)
+	public SpongePriceChestData(List<Double> value)
 	{
-		super(value, SpongyChest.PRICE_CHEST);
+		super(value, SpongyChest.PRICES_CHEST);
 	}
 
 	@Override
 	public Optional<PriceChestData> fill(DataHolder dataHolder, MergeFunction overlap)
 	{
 		PriceChestData typeOfChestData = Preconditions.checkNotNull(overlap).merge(copy(), from(dataHolder.toContainer()).orElse(null));
-		return Optional.of(set(SpongyChest.PRICE_CHEST, typeOfChestData.get(SpongyChest.PRICE_CHEST).get()));
+		return Optional.of(set(SpongyChest.PRICES_CHEST, typeOfChestData.get(SpongyChest.PRICES_CHEST).get()));
 	}
 
 	@Override
 	public DataContainer toContainer()
 	{
-		return super.toContainer().set(SpongyChest.PRICE_CHEST.getQuery(), this.getValue());
+		return super.toContainer().set(SpongyChest.PRICES_CHEST.getQuery(), this.getValue());
 	}
 
 	@Override
 	public Optional<PriceChestData> from(DataContainer container)
 	{
-		Double value = (Double) container.get(DataQuery.of("PriceChest")).orElse(null);
+		List<Double> value = (List<Double>) container.get(DataQuery.of("PriceChest")).orElse(null);
 
 		if (value != null)
 			return Optional.of(new SpongePriceChestData(value));
@@ -68,22 +71,24 @@ public class SpongePriceChestData extends AbstractSingleData<Double, PriceChestD
 	}
 
 	@Override
-	public Value<Double> price()
+	public ListValue<Double> prices()
 	{
-		return Sponge.getRegistry().getValueFactory().createValue(SpongyChest.PRICE_CHEST, this.getValue());
+		return Sponge.getRegistry().getValueFactory().createListValue(SpongyChest.PRICES_CHEST, this.getValue());
 	}
 
 	@Override
-	protected Value<?> getValueGetter()
+	protected ListValue<Double> getValueGetter()
 	{
-		return price();
+		return prices();
 	}
 
 	@Override
-	public int compareTo(PriceChestData o)
-	{
-		return ComparisonChain.start()
-			.compare(this.price().get(), o.price().get())
-			.result();
+	public Value<Double> sellPrice() {
+		return Sponge.getRegistry().getValueFactory().createValue(SpongyChest.SELL_PRICE_CHEST, this.getValue().get(SpongyChest.SELL_PRICE_INDEX));
+	}
+
+	@Override
+	public Value<Double> buyPrice() {
+		return Sponge.getRegistry().getValueFactory().createValue(SpongyChest.BUY_PRICE_CHEST, this.getValue().get(SpongyChest.BUY_PRICE_INDEX));
 	}
 }

--- a/src/main/java/io/github/hsyyid/spongychest/data/pricechest/SpongePriceChestData.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/pricechest/SpongePriceChestData.java
@@ -6,7 +6,6 @@ import io.github.hsyyid.spongychest.SpongyChest;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.DataContainer;
 import org.spongepowered.api.data.DataHolder;
-import org.spongepowered.api.data.DataQuery;
 import org.spongepowered.api.data.manipulator.mutable.common.AbstractListData;
 import org.spongepowered.api.data.merge.MergeFunction;
 import org.spongepowered.api.data.value.mutable.ListValue;
@@ -44,12 +43,24 @@ public class SpongePriceChestData extends AbstractListData<Double, PriceChestDat
 	@Override
 	public Optional<PriceChestData> from(DataContainer container)
 	{
-		List<Double> value = (List<Double>) container.get(DataQuery.of("PriceChest")).orElse(null);
+		List<Double> value = (List<Double>) container.get(SpongyChest.PRICES_CHEST.getQuery()).orElse(null);
 
 		if (value != null)
 			return Optional.of(new SpongePriceChestData(value));
 		else
+		{
+			if (container.contains(SpongyChest.SELL_PRICE_CHEST.getQuery()))
+			{
+				value = new ArrayList<>(2);
+				value.add(SpongyChest.SELL_PRICE_INDEX, (Double)container.get(SpongyChest.SELL_PRICE_CHEST.getQuery()).get());
+				value.add(SpongyChest.BUY_PRICE_INDEX, 0D);
+				PriceChestData data = new SpongePriceChestData(value);
+				container.remove(SpongyChest.SELL_PRICE_CHEST.getQuery());
+				container.set(SpongyChest.PRICES_CHEST.getQuery(), data);
+				return Optional.of(data);
+			}
 			return Optional.empty();
+		}
 	}
 
 	@Override

--- a/src/main/java/io/github/hsyyid/spongychest/listeners/HitBlockListener.java
+++ b/src/main/java/io/github/hsyyid/spongychest/listeners/HitBlockListener.java
@@ -1,8 +1,16 @@
 package io.github.hsyyid.spongychest.listeners;
 
+import io.github.hsyyid.spongychest.SpongyChest;
 import io.github.hsyyid.spongychest.data.isspongychest.IsSpongyChestData;
 import io.github.hsyyid.spongychest.data.isspongychest.SpongeIsSpongyChestData;
+import io.github.hsyyid.spongychest.data.itemchest.ItemChestData;
+import io.github.hsyyid.spongychest.data.pricechest.PriceChestData;
 import io.github.hsyyid.spongychest.data.uuidchest.UUIDChestData;
+import io.github.hsyyid.spongychest.utils.ChestUtils;
+import io.github.hsyyid.spongychest.utils.PlayerUtils;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntityChest;
+
 import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.block.tileentity.TileEntity;
 import org.spongepowered.api.block.tileentity.carrier.Chest;
@@ -11,11 +19,17 @@ import org.spongepowered.api.entity.hanging.ItemFrame;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.block.InteractBlockEvent;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.event.entity.InteractEntityEvent;
 import org.spongepowered.api.event.filter.cause.First;
+import org.spongepowered.api.item.inventory.ItemStackSnapshot;
+import org.spongepowered.api.service.economy.account.UniqueAccount;
+import org.spongepowered.api.service.economy.transaction.ResultType;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -40,6 +54,53 @@ public class HitBlockListener
 				else
 				{
 					event.setCancelled(true);
+
+					if (chest.get(IsSpongyChestData.class).isPresent() && chest.get(IsSpongyChestData.class).get().isSpongyChest().get())
+					{
+						ItemStackSnapshot item = chest.get(ItemChestData.class).get().itemStackSnapshot().get();
+						double price = chest.get(PriceChestData.class).get().buyPrice().get();
+						UUID ownerUuid = chest.get(UUIDChestData.class).get().uuid().get();
+						TileEntityChest realChest = (TileEntityChest) chest;
+						EntityPlayer realPlayer = (EntityPlayer) player;
+
+						if (player.getUniqueId().equals(ownerUuid))
+						{
+							return;
+						}
+
+						if (price == 0D)
+						{
+							player.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.RED, "The shop owner isn`t buying in this shop."));
+							return;
+						}
+
+						if (!ChestUtils.fitsItem(realChest, item))
+						{
+							player.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.GREEN, "The shop is full."));
+							return;
+						}
+
+						if (PlayerUtils.containsItem(realPlayer, item))
+						{
+							UniqueAccount ownerAccount = SpongyChest.economyService.getOrCreateAccount(ownerUuid).get();
+							UniqueAccount userAccount = SpongyChest.economyService.getOrCreateAccount(player.getUniqueId()).get();
+
+							if (ownerAccount.transfer(userAccount, SpongyChest.economyService.getDefaultCurrency(), new BigDecimal(price), Cause.of(NamedCause.source(player))).getResult() == ResultType.SUCCESS)
+							{
+								PlayerUtils.removeItems(realPlayer, item);
+								chest.getInventory().offer(item.createStack());
+								player.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.GREEN, "Sold item(s)."));
+							}
+							else
+							{
+								player.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.RED, "The shop owner has not enough money to buy your items."));
+							}
+						}
+						else
+						{
+							player.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.RED, "You have not enough items."));
+						}
+					}
 				}
 			}
 		}
@@ -69,6 +130,53 @@ public class HitBlockListener
 					else
 					{
 						event.setCancelled(true);
+
+						if (chest.get(IsSpongyChestData.class).isPresent() && chest.get(IsSpongyChestData.class).get().isSpongyChest().get())
+						{
+							ItemStackSnapshot item = chest.get(ItemChestData.class).get().itemStackSnapshot().get();
+							double price = chest.get(PriceChestData.class).get().buyPrice().get();
+							UUID ownerUuid = chest.get(UUIDChestData.class).get().uuid().get();
+							TileEntityChest realChest = (TileEntityChest) chest;
+							EntityPlayer realPlayer = (EntityPlayer) player;
+
+							if (player.getUniqueId().equals(ownerUuid))
+							{
+								return;
+							}
+
+							if (price == 0D)
+							{
+								player.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.RED, "The shop owner isn`t buying in this shop."));
+								return;
+							}
+
+							if (!ChestUtils.fitsItem(realChest, item))
+							{
+								player.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.GREEN, "The shop is full."));
+								return;
+							}
+
+							if (PlayerUtils.containsItem(realPlayer, item))
+							{
+								UniqueAccount ownerAccount = SpongyChest.economyService.getOrCreateAccount(ownerUuid).get();
+								UniqueAccount userAccount = SpongyChest.economyService.getOrCreateAccount(player.getUniqueId()).get();
+
+								if (ownerAccount.transfer(userAccount, SpongyChest.economyService.getDefaultCurrency(), new BigDecimal(price), Cause.of(NamedCause.source(player))).getResult() == ResultType.SUCCESS)
+								{
+									PlayerUtils.removeItems(realPlayer, item);
+									chest.getInventory().offer(item.createStack());
+									player.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.GREEN, "Sold item(s)."));
+								}
+								else
+								{
+									player.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.RED, "The shop owner has not enough money to buy your items."));
+								}
+							}
+							else
+							{
+								player.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.RED, "You have not enough items."));
+							}
+						}
 					}
 				}
 			}

--- a/src/main/java/io/github/hsyyid/spongychest/listeners/ItemFrameListener.java
+++ b/src/main/java/io/github/hsyyid/spongychest/listeners/ItemFrameListener.java
@@ -1,0 +1,37 @@
+package io.github.hsyyid.spongychest.listeners;
+
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.block.tileentity.carrier.Chest;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.entity.CollideEntityEvent;
+import org.spongepowered.api.event.filter.IsCancelled;
+import org.spongepowered.api.event.filter.cause.First;
+import org.spongepowered.api.util.Tristate;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+
+import io.github.hsyyid.spongychest.data.isspongychest.IsSpongyChestData;
+
+public class ItemFrameListener
+{
+	@Listener
+	@IsCancelled(Tristate.FALSE)
+	public void onCollideEntityImpact(CollideEntityEvent event, @First Player player)
+	{
+		for (Entity entity : event.getOriginalEntities())
+		{
+			Location<World> location = entity.getLocation().sub(0, 1, 0);
+			if (location.getBlockType() == BlockTypes.CHEST && location.getTileEntity().isPresent())
+			{
+				Chest chest = (Chest) location.getTileEntity().get();
+
+				if (chest.get(IsSpongyChestData.class).isPresent() && chest.get(IsSpongyChestData.class).get().isSpongyChest().get())
+				{
+					event.setCancelled(true);
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/io/github/hsyyid/spongychest/utils/ChestShopModifier.java
+++ b/src/main/java/io/github/hsyyid/spongychest/utils/ChestShopModifier.java
@@ -9,13 +9,15 @@ public class ChestShopModifier
 {
 	private UUID uuid;
 	private ItemStackSnapshot item;
-	private BigDecimal price;
+	private BigDecimal sellPrice;
+    private BigDecimal buyPrice;
 
-	public ChestShopModifier(UUID uuid, ItemStackSnapshot item, BigDecimal price)
+	public ChestShopModifier(UUID uuid, ItemStackSnapshot item, BigDecimal sellPrice, BigDecimal buyPrice)
 	{
 		this.uuid = uuid;
 		this.item = item;
-		this.price = price;
+		this.sellPrice = sellPrice;
+        this.buyPrice = buyPrice;
 	}
 
 	public UUID getUuid()
@@ -28,8 +30,13 @@ public class ChestShopModifier
 		return item;
 	}
 	
-	public BigDecimal getPrice()
+	public BigDecimal getSellPrice()
 	{
-		return price;
+		return sellPrice;
 	}
+    
+    public BigDecimal getBuyPrice()
+    {
+        return buyPrice;
+    }
 }

--- a/src/main/java/io/github/hsyyid/spongychest/utils/PlayerUtils.java
+++ b/src/main/java/io/github/hsyyid/spongychest/utils/PlayerUtils.java
@@ -1,31 +1,32 @@
 package io.github.hsyyid.spongychest.utils;
 
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntityChest;
-import net.minecraftforge.items.CapabilityItemHandler;
 import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
-public class ChestUtils
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.CapabilityItemHandler;
+
+public class PlayerUtils
 {
-	public static boolean fitsItem(TileEntityChest chest, ItemStackSnapshot snapshot)
+	public static boolean fitsItem(EntityPlayer player, ItemStackSnapshot snapshot)
 	{
 		int foundFreeItems = 0;
 		Item item = Item.getByNameOrId(snapshot.getType().getId());
 		
 		if (item != null)
 		{
-			for (int i = 0; i < chest.getSizeInventory(); i++)
+			for (int i = 0; i < player.inventory.getSizeInventory() - 4; i++)
 			{
-				ItemStack stack = chest.getStackInSlot(i);
+				ItemStack stack = player.inventory.getStackInSlot(i);
 				
 				if (stack == null)
 				{
-					foundFreeItems += chest.getInventoryStackLimit();
+					foundFreeItems += player.inventory.getInventoryStackLimit();
 				}
 				else if (stack.getItem().equals(item)) // TODO: Metadata && stack.getMetadata() == snapshot.)
 				{
-					foundFreeItems += chest.getInventoryStackLimit() - stack.stackSize;
+					foundFreeItems += player.inventory.getInventoryStackLimit() - stack.stackSize;
 				}
 
 				if (foundFreeItems >= snapshot.getCount())
@@ -38,16 +39,16 @@ public class ChestUtils
 		return false;
 	}
 
-	public static boolean containsItem(TileEntityChest chest, ItemStackSnapshot snapshot)
+	public static boolean containsItem(EntityPlayer player, ItemStackSnapshot snapshot)
 	{
 		int foundItems = 0;
 		Item item = Item.getByNameOrId(snapshot.getType().getId());
 
 		if (item != null)
 		{
-			for (int i = 0; i < chest.getSizeInventory(); i++)
+			for (int i = 0; i < player.inventory.getSizeInventory() - 4; i++)
 			{
-				ItemStack stack = chest.getStackInSlot(i);
+				ItemStack stack = player.inventory.getStackInSlot(i);
 
 				if (stack != null && stack.getItem().equals(item)) // TODO: Metadata && stack.getMetadata() == snapshot.)
 				{
@@ -64,7 +65,7 @@ public class ChestUtils
 		return false;
 	}
 
-	public static void removeItems(TileEntityChest chest, ItemStackSnapshot snapshot)
+	public static void removeItems(EntityPlayer player, ItemStackSnapshot snapshot)
 	{
 		int neededItems = snapshot.getCount();
 		int foundItems = 0;
@@ -72,15 +73,15 @@ public class ChestUtils
 
 		if (item != null)
 		{
-			for (int i = 0; i < chest.getSizeInventory(); i++)
+			for (int i = 0; i < player.inventory.getSizeInventory() - 4; i++)
 			{
-				ItemStack stack = chest.getStackInSlot(i);
+				ItemStack stack = player.inventory.getStackInSlot(i);
 
 				if (stack != null && stack.getItem().equals(item)) // TODO: Metadata && stack.getMetadata() == snapshot.)
 				{
 					if (neededItems >= foundItems + stack.stackSize)
 					{
-						chest.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).extractItem(i, stack.stackSize, false);
+						player.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).extractItem(i, stack.stackSize, false);
 						foundItems += stack.stackSize;
 					}
 					else
@@ -93,6 +94,7 @@ public class ChestUtils
 
 				if (foundItems == neededItems)
 				{
+					player.inventory.markDirty();
 					return;
 				}
 			}


### PR DESCRIPTION
Allows players to create shops on which items can be sold and bought.
Also shops which only sells or only buys are possible.

Also the inventories of the chest and the player are checked for free space, because sponge inserts the items to the armor slots if there is no more space.

Left click sells items if you are not the owner and you don`t have the destroy permission

The command is changed to:
`[] -> required`
`<> -> optional`
`/spongychest setshop [sellprice] <[buyprice]>`
`/spongychest setshop <-s sellprice> <-b buyprice>`
`/spongychest setshop <--sell-price=sellprice> <--buy-price=buyprice>`
