### PR TITLE
Update to 1.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 		}
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.1-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
     }
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
@@ -24,9 +24,9 @@ group = "io.github.hsyyid"
 archivesBaseName = "SpongyChest"
 
 minecraft {
-    version = "1.8.9-11.15.1.1808"
+    version = "1.11-13.19.0.2168"
     runDir = "run"
-    mappings = "stable_20"
+    mappings = "snapshot_20161111"
 }
 
 
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-	compile "org.spongepowered:spongeapi:4.0.3"
+	compile "org.spongepowered:spongeapi:6.0.0-20161126.155828-25"
 }
 
 jar {

--- a/src/main/java/io/github/hsyyid/spongychest/SpongyChest.java
+++ b/src/main/java/io/github/hsyyid/spongychest/SpongyChest.java
@@ -1,29 +1,14 @@
 package io.github.hsyyid.spongychest;
 
 import com.google.common.collect.Sets;
+import com.google.common.reflect.TypeToken;
 import com.google.inject.Inject;
 import io.github.hsyyid.spongychest.commands.SetShopExecutor;
 import io.github.hsyyid.spongychest.commands.SpongyChestExecutor;
-import io.github.hsyyid.spongychest.data.isspongychest.ImmutableIsSpongyChestData;
-import io.github.hsyyid.spongychest.data.isspongychest.ImmutableSpongeIsSpongyChestData;
-import io.github.hsyyid.spongychest.data.isspongychest.IsSpongyChestData;
-import io.github.hsyyid.spongychest.data.isspongychest.IsSpongyChestDataBuilder;
-import io.github.hsyyid.spongychest.data.isspongychest.SpongeIsSpongyChestData;
-import io.github.hsyyid.spongychest.data.itemchest.ImmutableItemChestData;
-import io.github.hsyyid.spongychest.data.itemchest.ImmutableSpongeItemChestData;
-import io.github.hsyyid.spongychest.data.itemchest.ItemChestData;
-import io.github.hsyyid.spongychest.data.itemchest.ItemChestDataBuilder;
-import io.github.hsyyid.spongychest.data.itemchest.SpongeItemChestData;
-import io.github.hsyyid.spongychest.data.pricechest.ImmutablePriceChestData;
-import io.github.hsyyid.spongychest.data.pricechest.ImmutableSpongePriceChestData;
-import io.github.hsyyid.spongychest.data.pricechest.PriceChestData;
-import io.github.hsyyid.spongychest.data.pricechest.PriceChestDataBuilder;
-import io.github.hsyyid.spongychest.data.pricechest.SpongePriceChestData;
-import io.github.hsyyid.spongychest.data.uuidchest.ImmutableSpongeUUIDChestData;
-import io.github.hsyyid.spongychest.data.uuidchest.ImmutableUUIDChestData;
-import io.github.hsyyid.spongychest.data.uuidchest.SpongeUUIDChestData;
-import io.github.hsyyid.spongychest.data.uuidchest.UUIDChestData;
-import io.github.hsyyid.spongychest.data.uuidchest.UUIDChestDataBuilder;
+import io.github.hsyyid.spongychest.data.isspongychest.*;
+import io.github.hsyyid.spongychest.data.itemchest.*;
+import io.github.hsyyid.spongychest.data.pricechest.*;
+import io.github.hsyyid.spongychest.data.uuidchest.*;
 import io.github.hsyyid.spongychest.listeners.HitBlockListener;
 import io.github.hsyyid.spongychest.listeners.InteractBlockListener;
 import io.github.hsyyid.spongychest.utils.ChestShopModifier;
@@ -47,24 +32,24 @@ import org.spongepowered.api.service.economy.EconomyService;
 import org.spongepowered.api.text.Text;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
-@Plugin(id = "io.github.hsyyid.spongychest", name = "SpongyChest", version = "0.4.7")
+@Plugin(
+		id = "spongychest",
+		name = "SpongyChest",
+		version = "0.4.7",
+		description = "SpongyChest is a plugin that utilizes Chests to make in-game item shops for players to sell items to each other!"
+)
 public class SpongyChest
 {
 	public static EconomyService economyService;
 	public static Set<ChestShopModifier> chestShopModifiers = Sets.newHashSet();
 
 	// Keys
-	public static final Key<Value<Boolean>> IS_SPONGY_CHEST = KeyFactory.makeSingleKey(Boolean.class, Value.class, DataQuery.of("IsSpongyChest"));
-	public static final Key<Value<UUID>> UUID_CHEST = KeyFactory.makeSingleKey(UUID.class, Value.class, DataQuery.of("UUIDChest"));
-	public static final Key<Value<ItemStackSnapshot>> ITEM_CHEST = KeyFactory.makeSingleKey(ItemStackSnapshot.class, Value.class, DataQuery.of("ItemChest"));
-	public static final Key<Value<Double>> PRICE_CHEST = KeyFactory.makeSingleKey(Double.class, Value.class, DataQuery.of("PriceChest"));
+	public static final Key<Value<Boolean>> IS_SPONGY_CHEST = KeyFactory.makeSingleKey(TypeToken.of(Boolean.class), new TypeToken<Value<Boolean>>() {}, DataQuery.of("IsSpongyChest"), "spongychest:is_spongy_chest", "Is SpongyChest");
+	public static final Key<Value<UUID>> UUID_CHEST = KeyFactory.makeSingleKey(TypeToken.of(UUID.class), new TypeToken<Value<UUID>>() {}, DataQuery.of("UUIDChest"), "spongychest:uuid_chest", "The UUID of the owner");
+	public static final Key<Value<ItemStackSnapshot>> ITEM_CHEST = KeyFactory.makeSingleKey(TypeToken.of(ItemStackSnapshot.class), new TypeToken<Value<ItemStackSnapshot>>() {}, DataQuery.of("ItemChest"), "spongychest:item_chest", "The actual item this SpongyChest sells/buys");
+	public static final Key<Value<Double>> PRICE_CHEST = KeyFactory.makeSingleKey(TypeToken.of(Double.class), new TypeToken<Value<Double>>() {}, DataQuery.of("PriceChest"), "spongychest:price_chest", "The price this SpongyChest sells/buys for");
 
 	@Inject
 	private Logger logger;

--- a/src/main/java/io/github/hsyyid/spongychest/commands/SetShopExecutor.java
+++ b/src/main/java/io/github/hsyyid/spongychest/commands/SetShopExecutor.java
@@ -7,6 +7,7 @@ import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.spec.CommandExecutor;
+import org.spongepowered.api.data.type.HandTypes;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
@@ -25,11 +26,11 @@ public class SetShopExecutor implements CommandExecutor
 		{
 			Player player = (Player) src;
 
-			if (player.getItemInHand().isPresent())
+			if (player.getItemInHand(HandTypes.MAIN_HAND).isPresent())
 			{
 				Optional<ChestShopModifier> modifier = SpongyChest.chestShopModifiers.stream().filter(m -> m.getUuid().equals(player.getUniqueId())).findAny();
 
-				ChestShopModifier chestShopModifier = new ChestShopModifier(player.getUniqueId(), player.getItemInHand().get().createSnapshot(), price);
+				ChestShopModifier chestShopModifier = new ChestShopModifier(player.getUniqueId(), player.getItemInHand(HandTypes.MAIN_HAND).get().createSnapshot(), price);
 
 				if (modifier.isPresent())
 				{

--- a/src/main/java/io/github/hsyyid/spongychest/commands/SpongyChestExecutor.java
+++ b/src/main/java/io/github/hsyyid/spongychest/commands/SpongyChestExecutor.java
@@ -13,7 +13,7 @@ public class SpongyChestExecutor implements CommandExecutor
 {
 	public CommandResult execute(CommandSource src, CommandContext ctx) throws CommandException
 	{
-		src.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.GRAY, "Version: ", TextColors.GOLD, Sponge.getPluginManager().getPlugin("io.github.hsyyid.spongychest").get().getVersion().get()));
+		src.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.GRAY, "Version: ", TextColors.GOLD, Sponge.getPluginManager().getPlugin("spongychest").get().getVersion().get()));
 		return CommandResult.success();
 	}
 }

--- a/src/main/java/io/github/hsyyid/spongychest/data/itemchest/ImmutableSpongeItemChestData.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/itemchest/ImmutableSpongeItemChestData.java
@@ -12,7 +12,7 @@ import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
 import java.util.Optional;
 
-public class ImmutableSpongeItemChestData extends AbstractImmutableSingleData<ItemStackSnapshot, ImmutableItemChestData, ItemChestData> implements ImmutableItemChestData
+public class ImmutableSpongeItemChestData extends AbstractImmutableSingleData<ItemStackSnapshot, ImmutableItemChestData, ItemChestData> implements ImmutableItemChestData, Comparable<ImmutableItemChestData>
 {
 	public ImmutableSpongeItemChestData(ItemStackSnapshot value)
 	{

--- a/src/main/java/io/github/hsyyid/spongychest/data/itemchest/SpongeItemChestData.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/itemchest/SpongeItemChestData.java
@@ -16,7 +16,7 @@ import org.spongepowered.api.item.inventory.ItemStackSnapshot;
 
 import java.util.Optional;
 
-public class SpongeItemChestData extends AbstractSingleData<ItemStackSnapshot, ItemChestData, ImmutableItemChestData> implements ItemChestData
+public class SpongeItemChestData extends AbstractSingleData<ItemStackSnapshot, ItemChestData, ImmutableItemChestData> implements ItemChestData, Comparable<ItemChestData>
 {
 	public SpongeItemChestData()
 	{

--- a/src/main/java/io/github/hsyyid/spongychest/data/pricechest/ImmutableSpongePriceChestData.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/pricechest/ImmutableSpongePriceChestData.java
@@ -11,7 +11,7 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 
 import java.util.Optional;
 
-public class ImmutableSpongePriceChestData extends AbstractImmutableSingleData<Double, ImmutablePriceChestData, PriceChestData> implements ImmutablePriceChestData
+public class ImmutableSpongePriceChestData extends AbstractImmutableSingleData<Double, ImmutablePriceChestData, PriceChestData> implements ImmutablePriceChestData, Comparable<ImmutablePriceChestData>
 {
 	public ImmutableSpongePriceChestData(Double value)
 	{

--- a/src/main/java/io/github/hsyyid/spongychest/data/pricechest/SpongePriceChestData.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/pricechest/SpongePriceChestData.java
@@ -13,7 +13,7 @@ import org.spongepowered.api.data.value.mutable.Value;
 
 import java.util.Optional;
 
-public class SpongePriceChestData extends AbstractSingleData<Double, PriceChestData, ImmutablePriceChestData> implements PriceChestData
+public class SpongePriceChestData extends AbstractSingleData<Double, PriceChestData, ImmutablePriceChestData> implements PriceChestData, Comparable<PriceChestData>
 {
 	public SpongePriceChestData()
 	{

--- a/src/main/java/io/github/hsyyid/spongychest/data/uuidchest/ImmutableSpongeUUIDChestData.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/uuidchest/ImmutableSpongeUUIDChestData.java
@@ -12,7 +12,7 @@ import org.spongepowered.api.data.value.immutable.ImmutableValue;
 import java.util.Optional;
 import java.util.UUID;
 
-public class ImmutableSpongeUUIDChestData extends AbstractImmutableSingleData<UUID, ImmutableUUIDChestData, UUIDChestData> implements ImmutableUUIDChestData
+public class ImmutableSpongeUUIDChestData extends AbstractImmutableSingleData<UUID, ImmutableUUIDChestData, UUIDChestData> implements ImmutableUUIDChestData, Comparable<ImmutableUUIDChestData>
 {
 	public ImmutableSpongeUUIDChestData(UUID value)
 	{

--- a/src/main/java/io/github/hsyyid/spongychest/data/uuidchest/SpongeUUIDChestData.java
+++ b/src/main/java/io/github/hsyyid/spongychest/data/uuidchest/SpongeUUIDChestData.java
@@ -14,7 +14,7 @@ import org.spongepowered.api.data.value.mutable.Value;
 import java.util.Optional;
 import java.util.UUID;
 
-public class SpongeUUIDChestData extends AbstractSingleData<UUID, UUIDChestData, ImmutableUUIDChestData> implements UUIDChestData
+public class SpongeUUIDChestData extends AbstractSingleData<UUID, UUIDChestData, ImmutableUUIDChestData> implements UUIDChestData, Comparable<UUIDChestData>
 {
 	public SpongeUUIDChestData()
 	{

--- a/src/main/java/io/github/hsyyid/spongychest/listeners/InteractBlockListener.java
+++ b/src/main/java/io/github/hsyyid/spongychest/listeners/InteractBlockListener.java
@@ -18,7 +18,6 @@ import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.block.tileentity.TileEntity;
 import org.spongepowered.api.block.tileentity.carrier.Chest;
 import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntityTypes;
 import org.spongepowered.api.entity.hanging.ItemFrame;
 import org.spongepowered.api.entity.living.player.Player;
@@ -101,21 +100,16 @@ public class InteractBlockListener
 					SpongyChest.chestShopModifiers.remove(chestShopModifier.get());
 
 					Location<World> frameLocation = chest.getLocation().add(0, 1, 0);
-					Optional<Entity> itemFrame = chest.getLocation().getExtent().createEntity(EntityTypes.ITEM_FRAME, frameLocation.getPosition());
+					ItemFrame entity = (ItemFrame) chest.getLocation().getExtent().createEntity(EntityTypes.ITEM_FRAME, frameLocation.getPosition());
+                    ItemStack frameStack = chestShopModifier.get().getItem().createStack();
+                    frameStack.offer(Keys.DISPLAY_NAME, Text.of(TextColors.GREEN, "Item: ", TextColors.WHITE, frameStack.getTranslation().get(), " ", TextColors.GREEN, "Amount: ", TextColors.WHITE, frameStack.getQuantity(), " ", TextColors.GREEN, "Price: ", TextColors.WHITE, SpongyChest.economyService.getDefaultCurrency().getSymbol().toPlain(), chestShopModifier.get().getPrice()));
+                    entity.offer(Keys.REPRESENTED_ITEM, frameStack.createSnapshot());
+                    ((EntityHanging) entity).updateFacingWithBoundingBox(EnumFacing.byName(chest.getLocation().getBlock().get(Keys.DIRECTION).get().name()));
 
-					if (itemFrame.isPresent())
-					{
-						ItemFrame entity = (ItemFrame) itemFrame.get();
-						ItemStack frameStack = chestShopModifier.get().getItem().createStack();
-						frameStack.offer(Keys.DISPLAY_NAME, Text.of(TextColors.GREEN, "Item: ", TextColors.WHITE, frameStack.getTranslation().get(), " ", TextColors.GREEN, "Amount: ", TextColors.WHITE, frameStack.getQuantity(), " ", TextColors.GREEN, "Price: ", TextColors.WHITE, SpongyChest.economyService.getDefaultCurrency().getSymbol().toPlain(), chestShopModifier.get().getPrice()));
-						entity.offer(Keys.REPRESENTED_ITEM, frameStack.createSnapshot());
-						((EntityHanging) entity).updateFacingWithBoundingBox(EnumFacing.byName(chest.getLocation().getBlock().get(Keys.DIRECTION).get().name()));
-
-						if (((EntityHanging) entity).onValidSurface())
-						{
-							chest.getLocation().getExtent().spawnEntity(entity, Cause.of(NamedCause.source(SpawnCause.builder().type(SpawnTypes.PLUGIN).build())));
-						}
-					}
+                    if (((EntityHanging) entity).onValidSurface())
+                    {
+                        chest.getLocation().getExtent().spawnEntity(entity, Cause.of(NamedCause.source(SpawnCause.builder().type(SpawnTypes.PLUGIN).build())));
+                    }
 
 					player.sendMessage(Text.of(TextColors.BLUE, "[SpongyChest]: ", TextColors.GREEN, "Created shop."));
 					event.setCancelled(true);

--- a/src/main/java/io/github/hsyyid/spongychest/utils/ChestUtils.java
+++ b/src/main/java/io/github/hsyyid/spongychest/utils/ChestUtils.java
@@ -20,7 +20,8 @@ public class ChestUtils
 
 				if (stack != null && stack.getItem().equals(item)) // TODO: Metadata && stack.getMetadata() == snapshot.)
 				{
-					foundItems += stack.stackSize;
+					// getStackSize
+					foundItems += stack.func_190916_E();
 
 					if (foundItems >= snapshot.getCount())
 					{
@@ -47,15 +48,15 @@ public class ChestUtils
 
 				if (stack != null && stack.getItem().equals(item)) // TODO: Metadata && stack.getMetadata() == snapshot.)
 				{
-					if (neededItems >= foundItems + stack.stackSize)
+					if (neededItems >= foundItems + stack.func_190916_E() /* getStackSize */)
 					{
 						chest.removeStackFromSlot(i);
-						foundItems += stack.stackSize;
+						foundItems += stack.func_190916_E(); /* getStackSize */
 					}
 					else
 					{
-						int amount = (foundItems + stack.stackSize) - neededItems;
-						stack.stackSize = amount;
+						int amount = (foundItems + stack.func_190916_E() /* getStackSize */) - neededItems;
+                        stack.func_190920_e(amount); /* setStackSize */
 						foundItems = neededItems;
 					}
 				}


### PR DESCRIPTION
Updates the plugin to 1.11 and also fixes a bug where the purchased items would disappear when the player had a full inventory. This fix is also used as a workaround to a current bug in Sponge, where no items are transferred when offering them to a player.